### PR TITLE
feat-rubrics-engine: added Plugin and Configuration to Criterion model.

### DIFF
--- a/apps/rubric-engine/application/Rubrics/Criterion.cs
+++ b/apps/rubric-engine/application/Rubrics/Criterion.cs
@@ -7,11 +7,13 @@ namespace RubricEngine.Application.Rubrics;
 [JsonConverter(typeof(CriterionConverter))]
 public sealed class Criterion : ValueObject
 {
-    private Criterion(CriterionName name, Percentage weight, List<PerformanceLevel> levels)
+    private Criterion(CriterionName name, Percentage weight, List<PerformanceLevel> levels, Plugin plugin, Configuration configuration)
     {
         Name = name;
         Weight = weight;
         Levels = levels;
+        Plugin = plugin;
+        Configuration = configuration;
     }
 
     public CriterionName Name { get; }
@@ -20,13 +22,19 @@ public sealed class Criterion : ValueObject
 
     public List<PerformanceLevel> Levels { get; } = [];
 
-    public static Criterion New(CriterionName name, Percentage weight, List<PerformanceLevel> levels)
-        => new(name, weight, levels);
+    public Plugin Plugin { get; } = Plugin.None;
+
+    public Configuration Configuration { get; } = Configuration.None;
+
+    public static Criterion New(CriterionName name, Percentage weight, List<PerformanceLevel> levels, Plugin plugin, Configuration configuration)
+        => new(name, weight, levels, plugin, configuration);
 
     protected override IEnumerable<object> GetEqualityComponents()
     {
         yield return Name;
-
+        yield return Weight;
+        yield return Plugin;
+        yield return Configuration;
         foreach (var level in Levels)
         {
             yield return level;
@@ -46,8 +54,10 @@ public sealed class CriterionConverter : JsonConverter<Criterion>
         var name = jObject.GetRequired<CriterionName>("Name");
         var weight = jObject.GetRequired<Percentage>("Weight");
         var levels = jObject.GetRequired<List<PerformanceLevel>>("Levels");
+        var plugin = jObject.GetRequired<Plugin>("Plugin");
+        var configuration = jObject.GetRequired<Configuration>("Configuration");
 
-        return Criterion.New(name, weight, levels);
+        return Criterion.New(name, weight, levels, plugin, configuration);
     }
 
     public override bool CanWrite => false;
@@ -68,7 +78,9 @@ public static class CriterionExtensions
         {
             Name = criterion.Name.Value,
             Weight = criterion.Weight.Value,
-            Levels = criterion.Levels.ToApiContract()
+            Levels = criterion.Levels.ToApiContract(),
+            Plugin = criterion.Plugin.Value,
+            Configuration = criterion.Configuration.Value
         };
     }
 }

--- a/apps/rubric-engine/application/Rubrics/CriterionApiContract.cs
+++ b/apps/rubric-engine/application/Rubrics/CriterionApiContract.cs
@@ -7,6 +7,8 @@ public class CriterionApiContract
 {
     public string Name { get; set; } = string.Empty;
     public decimal Weight { get; set; }
+    public string Plugin { get; set; } = string.Empty;
+    public string Configuration { get; set; } = string.Empty;
 
     public List<PerformanceLevelApiContract> Levels { get; set; } = [];
 }

--- a/apps/rubric-engine/application/Rubrics/ValueObjectExtensions.cs
+++ b/apps/rubric-engine/application/Rubrics/ValueObjectExtensions.cs
@@ -9,7 +9,12 @@ public static class ValueObjectExtensions
     public static List<Criterion> ToCriteria(this List<CriterionApiContract> criteria) => [.. criteria.Select(x => x.ToCriterion())];
 
     public static Criterion ToCriterion(this CriterionApiContract criterion)
-            => Criterion.New(CriterionName.New(criterion.Name), Percentage.New(criterion.Weight), criterion.Levels.ToPerformanceLevels());
+            => Criterion.New(
+                CriterionName.New(criterion.Name),
+                Percentage.New(criterion.Weight),
+                criterion.Levels.ToPerformanceLevels(),
+                Plugin.New(criterion.Plugin),
+                Configuration.New(criterion.Configuration));
 
     public static List<PerformanceLevel> ToPerformanceLevels(this List<PerformanceLevelApiContract> levels)
             => [.. levels.Select(x => PerformanceLevel.New(PerformanceTag.New(x.Tag), x.Description, Percentage.New(x.Weight)))];

--- a/apps/rubric-engine/application/Rubrics/ValueObjects.cs
+++ b/apps/rubric-engine/application/Rubrics/ValueObjects.cs
@@ -31,6 +31,24 @@ public sealed class CriterionName : StringValueObject
     public static CriterionName New(string value) => new(value);
 }
 
+public sealed class Plugin : StringValueObject
+{
+    public static Plugin None => new(string.Empty);
+    [JsonConstructor]
+    public Plugin(string value) : base(value) { }
+    protected override int? MaxLength => ModelConstants.ShortMediumText;
+    public static Plugin New(string value) => new(value);
+}
+
+public sealed class Configuration : StringValueObject
+{
+    public static Configuration None => new(string.Empty);
+    [JsonConstructor]
+    public Configuration(string value) : base(value) { }
+    protected override int? MaxLength => ModelConstants.ShortMediumText;
+    public static Configuration New(string value) => new(value);
+}
+
 /// <summary>
 /// Represents the current status of a Rubric in its lifecycle.
 /// </summary>


### PR DESCRIPTION
This pull request introduces two new properties, `Plugin` and `Configuration`, to the `Criterion` class in the rubric engine, enhancing its extensibility and configurability. The changes include updates to the class definition, its factory methods, serialization logic, and related API contracts.

### Enhancements to `Criterion` class:

* Added `Plugin` and `Configuration` properties to the `Criterion` class, including default values (`Plugin.None` and `Configuration.None`) and updates to the constructor and equality components. (`apps/rubric-engine/application/Rubrics/Criterion.cs`, [[1]](diffhunk://#diff-8196182756a1f30b7c70534c26f8a84ba41614e0daf01a333218918c1875e382L10-R16) [[2]](diffhunk://#diff-8196182756a1f30b7c70534c26f8a84ba41614e0daf01a333218918c1875e382L23-R37)

### Serialization and deserialization updates:

* Updated the `CriterionConverter` to handle the new `Plugin` and `Configuration` properties during JSON deserialization. (`apps/rubric-engine/application/Rubrics/Criterion.cs`, [apps/rubric-engine/application/Rubrics/Criterion.csR57-R60](diffhunk://#diff-8196182756a1f30b7c70534c26f8a84ba41614e0daf01a333218918c1875e382R57-R60))

### API contract changes:

* Added `Plugin` and `Configuration` fields to the `CriterionApiContract` class and updated the `ToApiContract` extension method to include these fields. (`apps/rubric-engine/application/Rubrics/CriterionApiContract.cs`, [[1]](diffhunk://#diff-746fcd04556c3a1cee745d75e81b5698bb2a8e0f08e28a99a54028cdf5edefc6R10-R11); `apps/rubric-engine/application/Rubrics/Criterion.cs`, [[2]](diffhunk://#diff-8196182756a1f30b7c70534c26f8a84ba41614e0daf01a333218918c1875e382L71-R83)

### Extension method updates:

* Modified the `ToCriterion` method in `ValueObjectExtensions` to map the new `Plugin` and `Configuration` fields from `CriterionApiContract` to `Criterion`. (`apps/rubric-engine/application/Rubrics/ValueObjectExtensions.cs`, [apps/rubric-engine/application/Rubrics/ValueObjectExtensions.csL12-R17](diffhunk://#diff-ddb0485ae5d7a420fa8bffe5ca0f28ba93526bd9bea6510e73b23c449d106d64L12-R17))

### New value objects:

* Introduced `Plugin` and `Configuration` as new `StringValueObject` types, including default values, constructors, and validation logic. (`apps/rubric-engine/application/Rubrics/ValueObjects.cs`, [apps/rubric-engine/application/Rubrics/ValueObjects.csR34-R51](diffhunk://#diff-937a580fead5ad660d66909d8bdb5860cec777487ce8a846529841da7ee0f33fR34-R51))