### PR TITLE
fix-rubric-engine: allowed Plugin and Configuration to be empty.

### DIFF
--- a/apps/rubric-engine/application/Rubrics/Criterion.cs
+++ b/apps/rubric-engine/application/Rubrics/Criterion.cs
@@ -22,9 +22,9 @@ public sealed class Criterion : ValueObject
 
     public List<PerformanceLevel> Levels { get; } = [];
 
-    public Plugin Plugin { get; } = Plugin.None;
+    public Plugin? Plugin { get; } = Plugin.None;
 
-    public Configuration Configuration { get; } = Configuration.None;
+    public Configuration? Configuration { get; }
 
     public static Criterion New(CriterionName name, Percentage weight, List<PerformanceLevel> levels, Plugin plugin, Configuration configuration)
         => new(name, weight, levels, plugin, configuration);

--- a/apps/rubric-engine/application/Rubrics/CriterionApiContract.cs
+++ b/apps/rubric-engine/application/Rubrics/CriterionApiContract.cs
@@ -1,13 +1,20 @@
-﻿using JsonApiDotNetCore.Resources.Annotations;
+﻿using System.ComponentModel.DataAnnotations;
+using JsonApiDotNetCore.Resources.Annotations;
 
 namespace RubricEngine.Application.Rubrics;
 
 [NoResource]
 public class CriterionApiContract
 {
-    public string Name { get; set; } = string.Empty;
-    public decimal Weight { get; set; }
+    [MaxLength(ModelConstants.ShortText)]
+    public required string Name { get; set; }
+    
+    public required decimal Weight { get; set; }
+
+    [MaxLength(ModelConstants.ShortText)]
     public string Plugin { get; set; } = string.Empty;
+    
+    [MaxLength(ModelConstants.ShortText)]
     public string Configuration { get; set; } = string.Empty;
 
     public List<PerformanceLevelApiContract> Levels { get; set; } = [];
@@ -16,8 +23,12 @@ public class CriterionApiContract
 [NoResource]
 public class PerformanceLevelApiContract
 {
+    [MaxLength(ModelConstants.ShortText)]
     public required string Tag { get; init; }
+
+    [MaxLength(ModelConstants.MediumText)]
     public required string Description { get; init; }
+    
     public required decimal Weight { get; init; }
 }
 

--- a/apps/rubric-engine/application/Rubrics/ValueObjects.cs
+++ b/apps/rubric-engine/application/Rubrics/ValueObjects.cs
@@ -37,6 +37,7 @@ public sealed class Plugin : StringValueObject
     [JsonConstructor]
     public Plugin(string value) : base(value) { }
     protected override int? MaxLength => ModelConstants.ShortMediumText;
+    protected override bool AllowEmpty => true;
     public static Plugin New(string value) => new(value);
 }
 
@@ -46,6 +47,7 @@ public sealed class Configuration : StringValueObject
     [JsonConstructor]
     public Configuration(string value) : base(value) { }
     protected override int? MaxLength => ModelConstants.ShortMediumText;
+    protected override bool AllowEmpty => true;
     public static Configuration New(string value) => new(value);
 }
 

--- a/tools/shared-dotnet/Shared.ValueObjects/StringValueObject.cs
+++ b/tools/shared-dotnet/Shared.ValueObjects/StringValueObject.cs
@@ -29,6 +29,8 @@ public abstract class StringValueObject : SingleValueObject<string>
 
     private void Validate(string value)
     {
+        if (AllowEmpty && string.IsNullOrEmpty(value)) return;
+
         if (!AllowEmpty && string.IsNullOrEmpty(value))
         {
             throw new ArgumentException("Value cannot be empty!", nameof(value));


### PR DESCRIPTION
This pull request introduces several changes to improve the flexibility and validation of the `Criterion` and related classes in the `rubric-engine` application. The most significant updates include making `Plugin` and `Configuration` properties nullable, adding validation attributes to API contracts, and enhancing the `StringValueObject` class to allow empty values when explicitly permitted.

### Updates to `Criterion` and related classes:

* **Nullable properties for flexibility**:
  - Made `Plugin` and `Configuration` properties nullable in `Criterion` to allow for optional values.

* **Validation attributes in API contracts**:
  - Added `[MaxLength]` attributes to enforce length constraints on `Name`, `Plugin`, `Configuration`, `Tag`, and `Description` properties in `CriterionApiContract` and `PerformanceLevelApiContract`.

### Enhancements to value objects:

* **Allow empty values in `Plugin` and `Configuration`**:
  - Updated `Plugin` and `Configuration` value objects to allow empty strings by overriding the `AllowEmpty` property.

* **Validation logic in `StringValueObject`**:
  - Modified the `Validate` method in `StringValueObject` to skip validation if `AllowEmpty` is true and the value is empty. 