### PR TITLE
Change requests/assignment flow allow empty grading creation

### DIFF
--- a/apps/assignment-flow/AssignmentFlow.Application/Gradings/ChangeRubric/ChangeRubricRequest.cs
+++ b/apps/assignment-flow/AssignmentFlow.Application/Gradings/ChangeRubric/ChangeRubricRequest.cs
@@ -1,0 +1,9 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace AssignmentFlow.Application.Gradings.ChangeRubric;
+
+public class ChangeRubricRequest
+{
+    [MaxLength(ModelConstants.ShortText)]
+    public required string RubricId { get; set; }
+}

--- a/apps/assignment-flow/AssignmentFlow.Application/Gradings/ChangeRubric/Command.cs
+++ b/apps/assignment-flow/AssignmentFlow.Application/Gradings/ChangeRubric/Command.cs
@@ -1,20 +1,20 @@
 ﻿using EventFlow.Commands;
 
-namespace AssignmentFlow.Application.Gradings.Create;
+namespace AssignmentFlow.Application.Gradings.ChangeRubric;
 
 public class Command(GradingId id) : Command<GradingAggregate, GradingId>(id)
 {
-    public required TeacherId TeacherId { get; init; }
+    public required RubricId Rubric { get; init; }
 }
 
 public class CommandHandler : CommandHandler<GradingAggregate, GradingId, Command>
 {
     public override Task ExecuteAsync(GradingAggregate aggregate, Command command, CancellationToken cancellationToken)
     {
-        if (!aggregate.IsNew)
+        if (aggregate.IsNew)
             return Task.CompletedTask;
 
-        aggregate.CreateGrading(command);
+        aggregate.ChangeRubric(command);
 
         return Task.CompletedTask;
     }

--- a/apps/assignment-flow/AssignmentFlow.Application/Gradings/ChangeRubric/EndpointHandler.cs
+++ b/apps/assignment-flow/AssignmentFlow.Application/Gradings/ChangeRubric/EndpointHandler.cs
@@ -1,0 +1,33 @@
+﻿using EventFlow;
+using Microsoft.AspNetCore.Mvc;
+
+namespace AssignmentFlow.Application.Gradings.ChangeRubric;
+
+public static class EndpointHandler
+{
+    public static IEndpointRouteBuilder MapChangeRubric(this IEndpointRouteBuilder endpoint)
+    {
+        endpoint.MapPut("/{id}/rubric", ChangeRubric)
+            .WithName("ChangeRubric")
+            .Produces(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status400BadRequest);
+
+        return endpoint;
+    }
+
+    private static async Task<IResult> ChangeRubric(
+        [FromRoute] string id,
+        [FromBody] ChangeRubricRequest request,
+        ICommandBus commandBus,
+        IHttpContextAccessor contextAccessor,
+        CancellationToken cancellationToken)
+    {
+        var gradingId = GradingId.With(id);
+        await commandBus.PublishAsync(new Command(gradingId)
+        {
+            Rubric = RubricId.With(request.RubricId)
+        }, cancellationToken);
+
+        return TypedResults.Ok();
+    }
+}

--- a/apps/assignment-flow/AssignmentFlow.Application/Gradings/ChangeRubric/RubricChangedEvent.cs
+++ b/apps/assignment-flow/AssignmentFlow.Application/Gradings/ChangeRubric/RubricChangedEvent.cs
@@ -1,0 +1,10 @@
+﻿using EventFlow.Aggregates;
+using EventFlow.EventStores;
+
+namespace AssignmentFlow.Application.Gradings.ChangeRubric;
+
+[EventVersion("rubricChanged", 1)]
+public class RubricChangedEvent : AggregateEvent<GradingAggregate, GradingId>
+{
+    public required RubricId RubricId { get; set; }
+}

--- a/apps/assignment-flow/AssignmentFlow.Application/Gradings/Create/CreateGradingRequest.cs
+++ b/apps/assignment-flow/AssignmentFlow.Application/Gradings/Create/CreateGradingRequest.cs
@@ -1,8 +1,0 @@
-﻿namespace AssignmentFlow.Application.Gradings.Create;
-
-public class CreateGradingRequest
-{
-    public string RubricId { get; init; } = string.Empty;
-    public decimal ScaleFactor { get; init; } = 10M; // optional, default to 10
-    public List<SelectorApiContract> Selectors { get; set; } = [];
-}

--- a/apps/assignment-flow/AssignmentFlow.Application/Gradings/Create/EndpointHandler.cs
+++ b/apps/assignment-flow/AssignmentFlow.Application/Gradings/Create/EndpointHandler.cs
@@ -17,7 +17,12 @@ public static class EndpointHandler
         return endpoint;
     }
 
+    public class CreateRubricRequest
+    {
+    }
+
     private static async Task<IResult> CreateGrading(
+        CreateRubricRequest _,
         ICommandBus commandBus,
         IQueryProcessor queryProcessor,
         IHttpContextAccessor contextAccessor,

--- a/apps/assignment-flow/AssignmentFlow.Application/Gradings/Create/EndpointHandler.cs
+++ b/apps/assignment-flow/AssignmentFlow.Application/Gradings/Create/EndpointHandler.cs
@@ -18,7 +18,6 @@ public static class EndpointHandler
     }
 
     private static async Task<IResult> CreateGrading(
-        [FromBody] CreateGradingRequest request,
         ICommandBus commandBus,
         IQueryProcessor queryProcessor,
         IHttpContextAccessor contextAccessor,
@@ -26,17 +25,11 @@ public static class EndpointHandler
         CancellationToken cancellationToken)
     {
         var teacherId = TeacherId.With("teacher");
-        var rubric = await rubricProto.GetRubricAsync(new GetRubricRequest
-        {
-            RubricId = request.RubricId
-        }, cancellationToken: cancellationToken);
-        
+
         var gradingId = GradingId.NewComb();
         await commandBus.PublishAsync(new Command(gradingId)
         {
-            TeacherId = teacherId,
-            RubricId = RubricId.With(rubric.Id),
-            Selectors = request.Selectors.ConvertAll(s => s.ToValueObject())
+            TeacherId = teacherId
         }, cancellationToken);
 
         return TypedResults.Created("/", gradingId.Value);

--- a/apps/assignment-flow/AssignmentFlow.Application/Gradings/Create/GradingCreatedEvent.cs
+++ b/apps/assignment-flow/AssignmentFlow.Application/Gradings/Create/GradingCreatedEvent.cs
@@ -7,7 +7,4 @@ namespace AssignmentFlow.Application.Gradings.Create;
 public class GradingCreatedEvent : AggregateEvent<GradingAggregate, GradingId>
 {
     public required TeacherId TeacherId { get; init; }
-    public required RubricId RubricId { get; init; }
-    public required ScaleFactor ScaleFactor { get; init; }
-    public required List<Selector> Selectors { get; init; }
 }

--- a/apps/assignment-flow/AssignmentFlow.Application/Gradings/EndpointHandlers.cs
+++ b/apps/assignment-flow/AssignmentFlow.Application/Gradings/EndpointHandlers.cs
@@ -1,4 +1,5 @@
-﻿using AssignmentFlow.Application.Gradings.Create;
+﻿using AssignmentFlow.Application.Gradings.ChangeRubric;
+using AssignmentFlow.Application.Gradings.Create;
 using AssignmentFlow.Application.Gradings.Start;
 using AssignmentFlow.Application.Gradings.UpdateCriterionSelectors;
 using AssignmentFlow.Application.Gradings.UpdateScaleFactor;
@@ -19,6 +20,7 @@ internal static class EndpointHandlers
             .MapUpdateCriterionSelectors()
             .MapUpdateScaleFactor()
             .MapUploadSubmission()
+            .MapChangeRubric()
             .MapStartGrading();
             
         return routeBuilder;

--- a/apps/assignment-flow/AssignmentFlow.Application/Gradings/Grading.cs
+++ b/apps/assignment-flow/AssignmentFlow.Application/Gradings/Grading.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using AssignmentFlow.Application.Gradings.ChangeRubric;
 using AssignmentFlow.Application.Gradings.Create;
 using AssignmentFlow.Application.Gradings.Start;
 using AssignmentFlow.Application.Gradings.UpdateCriterionSelectors;
@@ -21,6 +22,7 @@ public class Grading
     IAmReadModelFor<GradingAggregate, GradingId, GradingCreatedEvent>,
     IAmReadModelFor<GradingAggregate, GradingId, SelectorsUpdatedEvent>,
     IAmReadModelFor<GradingAggregate, GradingId, ScaleFactorUpdatedEvent>,
+    IAmReadModelFor<GradingAggregate, GradingId, RubricChangedEvent>,
     IAmReadModelFor<GradingAggregate, GradingId, SubmissionAddedEvent>,
     IAmReadModelFor<GradingAggregate, GradingId, GradingStartedEvent>
 {
@@ -120,6 +122,14 @@ public class Grading
     public Task ApplyAsync(IReadModelContext context, IDomainEvent<GradingAggregate, GradingId, ScaleFactorUpdatedEvent> domainEvent, CancellationToken cancellationToken)
     {
         ScaleFactor = domainEvent.AggregateEvent.ScaleFactor;
+        UpdateLastModifiedData(domainEvent);
+        return Task.CompletedTask;
+    }
+
+    public Task ApplyAsync(IReadModelContext context, IDomainEvent<GradingAggregate, GradingId, RubricChangedEvent> domainEvent, CancellationToken cancellationToken)
+    {
+        RubricId = domainEvent.AggregateEvent.RubricId.Value;
+        Selectors = [];
         UpdateLastModifiedData(domainEvent);
         return Task.CompletedTask;
     }

--- a/apps/assignment-flow/AssignmentFlow.Application/Gradings/Grading.cs
+++ b/apps/assignment-flow/AssignmentFlow.Application/Gradings/Grading.cs
@@ -91,14 +91,6 @@ public class Grading
         CancellationToken cancellationToken)
     {
         TeacherId = domainEvent.AggregateEvent.TeacherId.Value;
-        RubricId = domainEvent.AggregateEvent.RubricId.Value;
-        ScaleFactor = domainEvent.AggregateEvent.ScaleFactor;
-        Selectors = domainEvent.AggregateEvent.Selectors
-            .ConvertAll(s => new SelectorApiContract
-            {
-                Criterion = s.Criterion,
-                Pattern = s.Pattern
-            });
 
         UpdateLastModifiedData(domainEvent);
         return Task.CompletedTask;

--- a/apps/assignment-flow/AssignmentFlow.Application/Gradings/GradingAggregate.cs
+++ b/apps/assignment-flow/AssignmentFlow.Application/Gradings/GradingAggregate.cs
@@ -22,10 +22,7 @@ public class GradingAggregate : AggregateRoot<GradingAggregate, GradingId>
     {
         Emit(new Create.GradingCreatedEvent
         {
-            TeacherId = command.TeacherId,
-            RubricId = command.RubricId,
-            ScaleFactor = command.ScaleFactor,
-            Selectors = command.Selectors
+            TeacherId = command.TeacherId
         });
     }
 
@@ -45,8 +42,13 @@ public class GradingAggregate : AggregateRoot<GradingAggregate, GradingId>
         });
     }
 
-    public Pattern GetGlobalPattern() => this.State.GlobalPattern;
-    public List<Selector> GetCriterionAttachmentsSelectors() => this.State.Selectors;
+    public void ChangeRubric(ChangeRubric.Command command)
+    {
+        Emit(new ChangeRubric.RubricChangedEvent
+        {
+            RubricId = command.Rubric
+        });
+    }
 
     public void AddSubmission(Submission submission)
     {

--- a/apps/assignment-flow/AssignmentFlow.Application/Gradings/GradingWriteModel.cs
+++ b/apps/assignment-flow/AssignmentFlow.Application/Gradings/GradingWriteModel.cs
@@ -1,4 +1,5 @@
-﻿using AssignmentFlow.Application.Gradings.Create;
+﻿using AssignmentFlow.Application.Gradings.ChangeRubric;
+using AssignmentFlow.Application.Gradings.Create;
 using AssignmentFlow.Application.Gradings.Start;
 using AssignmentFlow.Application.Gradings.UpdateCriterionSelectors;
 using AssignmentFlow.Application.Gradings.UpdateScaleFactor;
@@ -10,29 +11,17 @@ namespace AssignmentFlow.Application.Gradings;
 public class GradingWriteModel : AggregateState<GradingAggregate, GradingId, GradingWriteModel>
 {
     public TeacherId TeacherId { get; private set; } = TeacherId.Empty;
-    
+    public RubricId RubricId { get; private set; } = RubricId.Empty;
     public ScaleFactor ScaleFactor { get; private set; } = ScaleFactor.TenPoint;
-
-    public Pattern GlobalPattern
-    {
-        get
-        {
-            var patterns = string.Join(",",
-                Selectors.Select(s => s.Pattern.Value));
-            return Pattern.New(patterns);
-        }
-        private set{}
-    }
     public List<Selector> Selectors { get; private set; } = [];
-
+   
     public List<Submission> Submissions { get; private set; } = [];
-    
+   
     public GradingStateMachine StateMachine { get; private set; } = new();
 
     internal void Apply(GradingCreatedEvent @event)
     {
         TeacherId = @event.TeacherId;
-        Selectors = @event.Selectors;
     }
 
     internal void Apply(SelectorsUpdatedEvent @event)
@@ -43,6 +32,12 @@ public class GradingWriteModel : AggregateState<GradingAggregate, GradingId, Gra
     internal void Apply(ScaleFactorUpdatedEvent @event)
     {
         ScaleFactor = @event.ScaleFactor;
+    }
+
+    internal void Apply(RubricChangedEvent @event)
+    {
+        RubricId = @event.RubricId;
+        Selectors = [];
     }
 
     internal void Apply(SubmissionAddedEvent @event)

--- a/apps/assignment-flow/AssignmentFlow.Application/Shared/RubricId.cs
+++ b/apps/assignment-flow/AssignmentFlow.Application/Shared/RubricId.cs
@@ -10,5 +10,6 @@ public sealed class RubricId : StringValueObject
     [JsonConstructor]
     public RubricId(string value) : base(value) { }
 
+    protected override bool AllowEmpty => true;
     public static RubricId With(string value) => new(value);
 }


### PR DESCRIPTION
This pull request introduces a new feature for changing the rubric associated with a grading in the `AssignmentFlow` application while also removing rubric-related functionality from the grading creation process. The changes include adding a new command, event, and endpoint for changing the rubric, as well as updating the domain model and write model to reflect these changes.

### New Feature: Change Rubric

* Added a new `ChangeRubricRequest` class to handle rubric change requests, with a `RubricId` property that is required and validated for maximum length. (`apps/assignment-flow/AssignmentFlow.Application/Gradings/ChangeRubric/ChangeRubricRequest.cs`)
* Introduced a `Command` class and `CommandHandler` for handling rubric change commands, including logic to update the aggregate only if it is not new. (`apps/assignment-flow/AssignmentFlow.Application/Gradings/ChangeRubric/Command.cs`)
* Created a `RubricChangedEvent` to capture rubric change events in the domain model. (`apps/assignment-flow/AssignmentFlow.Application/Gradings/ChangeRubric/RubricChangedEvent.cs`)
* Added an endpoint handler for the `ChangeRubric` operation, exposing a PUT endpoint to update the rubric for a grading. (`apps/assignment-flow/AssignmentFlow.Application/Gradings/ChangeRubric/EndpointHandler.cs`)
* Updated the `Grading` and `GradingWriteModel` classes to handle the new `RubricChangedEvent`, resetting selectors and updating the rubric ID when the event is applied. (`apps/assignment-flow/AssignmentFlow.Application/Gradings/Grading.cs`, `apps/assignment-flow/AssignmentFlow.Application/Gradings/GradingWriteModel.cs`) [[1]](diffhunk://#diff-e9698fbf0c2dae5f7d25d46bc504b2fb292459a2373d4ad3c3efda4627932487R121-R128) [[2]](diffhunk://#diff-a63a2eed1efa165fc2ae232a5e3a7209cd94d461ea15b777b28d03828eff53d8R37-R42)

### Removal of Rubric from Grading Creation

* Removed `RubricId`, `ScaleFactor`, and `Selectors` properties from the `CreateGradingRequest`, `Create.Command`, and related event classes. (`apps/assignment-flow/AssignmentFlow.Application/Gradings/Create/CreateGradingRequest.cs`, `apps/assignment-flow/AssignmentFlow.Application/Gradings/Create/Command.cs`, `apps/assignment-flow/AssignmentFlow.Application/Gradings/Create/GradingCreatedEvent.cs`) [[1]](diffhunk://#diff-8de3e09be934e79b82932d8fc1323d002cc91aea308394c49996fb272d0e3a37L1-L8) [[2]](diffhunk://#diff-19fa2119cdd5fdbdd196fec35dccdbdd62fa3a8650c584ea713ce2326ea97ac4L8-L10) [[3]](diffhunk://#diff-7b852a1690227678e7dd5347d100a76840bfe4c9208ef903513ddff2cd28325bL10-L12)
* Simplified the `CreateGrading` endpoint by removing logic related to fetching and validating the rubric during grading creation. (`apps/assignment-flow/AssignmentFlow.Application/Gradings/Create/EndpointHandler.cs`)

### Domain and Infrastructure Updates

* Added a `ChangeRubric` method to the `GradingAggregate` to emit the `RubricChangedEvent` when invoked. (`apps/assignment-flow/AssignmentFlow.Application/Gradings/GradingAggregate.cs`)
* Updated the `RubricId` value object to allow empty values, aligning with the changes in rubric handling. (`apps/assignment-flow/AssignmentFlow.Application/Shared/RubricId.cs`)

### Endpoint and Dependency Integration

* Registered the `ChangeRubric` endpoint in the main endpoint handler for gradings. (`apps/assignment-flow/AssignmentFlow.Application/Gradings/EndpointHandlers.cs`)
* Imported the necessary namespaces for the new rubric change functionality across relevant files. (`apps/assignment-flow/AssignmentFlow.Application/Gradings/EndpointHandlers.cs`, `apps/assignment-flow/AssignmentFlow.Application/Gradings/Grading.cs`, `apps/assignment-flow/AssignmentFlow.Application/Gradings/GradingWriteModel.cs`) [[1]](diffhunk://#diff-c52dda9018f969f3bc91f69510215672da9eb04149356295b0574a5c9b52e4a3L1-R2) [[2]](diffhunk://#diff-e9698fbf0c2dae5f7d25d46bc504b2fb292459a2373d4ad3c3efda4627932487R3) [[3]](diffhunk://#diff-a63a2eed1efa165fc2ae232a5e3a7209cd94d461ea15b777b28d03828eff53d8L1-R2)