### PR TITLE
Added submission removal feature to grading system

### DIFF
--- a/apps/assignment-flow/AssignmentFlow.Application/Gradings/EndpointHandlers.cs
+++ b/apps/assignment-flow/AssignmentFlow.Application/Gradings/EndpointHandlers.cs
@@ -1,5 +1,6 @@
 ﻿using AssignmentFlow.Application.Gradings.ChangeRubric;
 using AssignmentFlow.Application.Gradings.Create;
+using AssignmentFlow.Application.Gradings.RemoveSubmission;
 using AssignmentFlow.Application.Gradings.Start;
 using AssignmentFlow.Application.Gradings.UpdateCriterionSelectors;
 using AssignmentFlow.Application.Gradings.UpdateScaleFactor;
@@ -20,6 +21,7 @@ internal static class EndpointHandlers
             .MapUpdateCriterionSelectors()
             .MapUpdateScaleFactor()
             .MapUploadSubmission()
+            .MapRemoveSubmission()
             .MapChangeRubric()
             .MapStartGrading();
             

--- a/apps/assignment-flow/AssignmentFlow.Application/Gradings/Grading.cs
+++ b/apps/assignment-flow/AssignmentFlow.Application/Gradings/Grading.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel.DataAnnotations.Schema;
 using AssignmentFlow.Application.Gradings.ChangeRubric;
 using AssignmentFlow.Application.Gradings.Create;
+using AssignmentFlow.Application.Gradings.RemoveSubmission;
 using AssignmentFlow.Application.Gradings.Start;
 using AssignmentFlow.Application.Gradings.UpdateCriterionSelectors;
 using AssignmentFlow.Application.Gradings.UpdateScaleFactor;
@@ -22,6 +23,7 @@ public class Grading
     IAmReadModelFor<GradingAggregate, GradingId, ScaleFactorUpdatedEvent>,
     IAmReadModelFor<GradingAggregate, GradingId, RubricChangedEvent>,
     IAmReadModelFor<GradingAggregate, GradingId, SubmissionAddedEvent>,
+    IAmReadModelFor<GradingAggregate, GradingId, SubmissionRemovedEvent>,
     IAmReadModelFor<GradingAggregate, GradingId, AutoGradingStartedEvent>,
     IAmReadModelFor<GradingAggregate, GradingId, AutoGradingFinishedEvent>
 {
@@ -128,6 +130,14 @@ public class Grading
             Attachments = submission.Attachments.ConvertAll(a => a.Value)
         });
         
+        UpdateLastModifiedData(domainEvent);
+        return Task.CompletedTask;
+    }
+
+    public Task ApplyAsync(IReadModelContext context, IDomainEvent<GradingAggregate, GradingId, SubmissionRemovedEvent> domainEvent, CancellationToken cancellationToken)
+    {
+        SubmissionPersistences.RemoveAll(s => s.Reference == domainEvent.AggregateEvent.RemovedSubmission);
+
         UpdateLastModifiedData(domainEvent);
         return Task.CompletedTask;
     }

--- a/apps/assignment-flow/AssignmentFlow.Application/Gradings/GradingAggregate.cs
+++ b/apps/assignment-flow/AssignmentFlow.Application/Gradings/GradingAggregate.cs
@@ -57,6 +57,14 @@ public class GradingAggregate : AggregateRoot<GradingAggregate, GradingId>
         Emit(new UploadSubmission.SubmissionAddedEvent(submission));
     }
 
+    public void RemoveSubmission(RemoveSubmission.Command command)
+    {
+        Emit(new RemoveSubmission.SubmissionRemovedEvent
+        {
+            RemovedSubmission = command.SubmissionReference 
+        });
+    }
+
     public void StartAutoGrading()
     {
         Start.GradingCanBeStartedSpecification.New().ThrowDomainErrorIfNotSatisfied(State);

--- a/apps/assignment-flow/AssignmentFlow.Application/Gradings/GradingWriteModel.cs
+++ b/apps/assignment-flow/AssignmentFlow.Application/Gradings/GradingWriteModel.cs
@@ -1,5 +1,6 @@
 ﻿using AssignmentFlow.Application.Gradings.ChangeRubric;
 using AssignmentFlow.Application.Gradings.Create;
+using AssignmentFlow.Application.Gradings.RemoveSubmission;
 using AssignmentFlow.Application.Gradings.Start;
 using AssignmentFlow.Application.Gradings.UpdateCriterionSelectors;
 using AssignmentFlow.Application.Gradings.UpdateScaleFactor;
@@ -43,6 +44,11 @@ public class GradingWriteModel : AggregateState<GradingAggregate, GradingId, Gra
     internal void Apply(SubmissionAddedEvent @event)
     {
         Submissions.Add(@event.Submission);
+    }
+
+    internal void Apply(SubmissionRemovedEvent @event)
+    {
+        Submissions.RemoveAll(s => s.Reference == @event.RemovedSubmission);
     }
 
     internal void Apply(AutoGradingStartedEvent @event)

--- a/apps/assignment-flow/AssignmentFlow.Application/Gradings/RemoveSubmission/Command.cs
+++ b/apps/assignment-flow/AssignmentFlow.Application/Gradings/RemoveSubmission/Command.cs
@@ -1,0 +1,44 @@
+﻿using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using EventFlow.Commands;
+
+namespace AssignmentFlow.Application.Gradings.RemoveSubmission;
+
+public class Command(GradingId aggregateId, SubmissionReference submissionReference) : Command<GradingAggregate, GradingId>(aggregateId)
+{
+    public SubmissionReference SubmissionReference { get; } = submissionReference;
+}
+
+public class CommandHandler(BlobServiceClient client) : CommandHandler<GradingAggregate, GradingId, Command>
+{
+    public override async Task ExecuteAsync(GradingAggregate aggregate, Command command,
+        CancellationToken cancellationToken)
+    {
+        if (aggregate.IsNew)
+            throw new InvalidOperationException(
+                $"Cannot remove submission for grading {aggregate.Id} because it has not been created yet.");
+
+        var container = client.GetBlobContainerClient("submissions-store");
+        var submissionFolderPath = $"{aggregate.Id}/{command.SubmissionReference}";
+        try
+        {
+            var blobItems = container.GetBlobsAsync(
+                prefix: submissionFolderPath,
+                cancellationToken: cancellationToken);
+
+            await foreach (BlobItem blobItem in blobItems)
+            {
+                BlobClient blobClient = container.GetBlobClient(blobItem.Name);
+                await blobClient.DeleteIfExistsAsync(cancellationToken: cancellationToken);
+            }
+
+            aggregate.RemoveSubmission(command);
+        }
+        catch (Exception ex)
+        {
+            // Handle exceptions from the blob storage operations
+            throw new InvalidOperationException(
+                $"Failed to remove submission {command.SubmissionReference} for grading {aggregate.Id}", ex);
+        }
+    }
+}

--- a/apps/assignment-flow/AssignmentFlow.Application/Gradings/RemoveSubmission/EndpointHandler.cs
+++ b/apps/assignment-flow/AssignmentFlow.Application/Gradings/RemoveSubmission/EndpointHandler.cs
@@ -1,0 +1,38 @@
+﻿using EventFlow;
+using EventFlow.Queries;
+using Microsoft.AspNetCore.Mvc;
+
+namespace AssignmentFlow.Application.Gradings.RemoveSubmission;
+
+public static class EndpointHandler
+{
+    public static IEndpointRouteBuilder MapRemoveSubmission(this IEndpointRouteBuilder endpoint)
+    {
+        endpoint.MapDelete("/{grading:required}/submissions/{reference:required}", UploadSubmission)
+            .WithName("RemoveSubmission")
+            .Produces<string>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .DisableAntiforgery(); // Disable for now
+
+        return endpoint;
+    }
+
+    private static async Task<IResult> UploadSubmission(
+        [FromRoute] string grading,
+        [FromRoute] string reference,
+        ICommandBus commandBus,
+        GradingRepository gradingRepository,
+        IQueryProcessor queryProcessor,
+        IHttpContextAccessor contextAccessor,
+        CancellationToken cancellationToken)
+    {
+        var gradingId = GradingId.With(grading);
+        var submissionReference = SubmissionReference.New(reference);
+
+        await commandBus.PublishAsync(
+            new Command(gradingId, submissionReference),
+            cancellationToken);
+
+        return TypedResults.Ok();
+    }
+}

--- a/apps/assignment-flow/AssignmentFlow.Application/Gradings/RemoveSubmission/SubmissionRemovedEvent.cs
+++ b/apps/assignment-flow/AssignmentFlow.Application/Gradings/RemoveSubmission/SubmissionRemovedEvent.cs
@@ -1,0 +1,10 @@
+﻿using EventFlow.Aggregates;
+using EventFlow.EventStores;
+
+namespace AssignmentFlow.Application.Gradings.RemoveSubmission;
+
+[EventVersion("submissionRemoved", 1)]
+public class SubmissionRemovedEvent : AggregateEvent<GradingAggregate, GradingId>
+{
+    public required SubmissionReference RemovedSubmission { get; init; }
+}

--- a/apps/assignment-flow/AssignmentFlow.Application/Gradings/UploadSubmission/EndpointHandler.cs
+++ b/apps/assignment-flow/AssignmentFlow.Application/Gradings/UploadSubmission/EndpointHandler.cs
@@ -19,7 +19,7 @@ public static class EndpointHandler
 
     private static async Task<IResult> UploadSubmission(
         [FromRoute] string id,
-        [FromForm] IFormFile file, //zip only
+        [FromForm] IFormFile file,
         ICommandBus commandBus,
         GradingRepository gradingRepository,
         IQueryProcessor queryProcessor,
@@ -28,7 +28,7 @@ public static class EndpointHandler
     {
         var gradingId = GradingId.With(id);
         var studentId = ExtractStudentId(file.FileName);
-        var reference = SubmissionReference.New($"{gradingId}_{studentId}");
+        var reference = SubmissionReference.New(studentId);
 
         await commandBus.PublishAsync(
             new Command(gradingId)


### PR DESCRIPTION
This commit introduces a new feature for removing submissions in the grading system. It includes the addition of a `RemoveSubmission` command, event, and endpoint handler.

Key changes:
- Added `MapRemoveSubmission` method in `EndpointHandlers.cs` to define a new API endpoint for deleting submissions.
- Updated `Grading` class in `Grading.cs` to handle the new `SubmissionRemovedEvent`.
- Enhanced `GradingAggregate` to emit `SubmissionRemovedEvent` upon submission removal.
- Modified `GradingWriteModel` to apply the `SubmissionRemovedEvent` for state consistency.
- Created a new `Command` class in `Command.cs` to encapsulate parameters for submission removal.
- Updated `CommandHandler` to execute the `RemoveSubmission` command and delete associated blobs from Azure Blob Storage.
- Introduced `SubmissionRemovedEvent` class to represent the removal event with necessary properties.

These changes improve the grading system by allowing for the effective removal of submissions.