### PR TITLE
Features/rubric engine additional context

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Aspire.Azure.Storage.Blobs" Version="9.2.1" />
+    <PackageVersion Include="Aspire.Azure.Storage.Blobs" Version="9.3.1" />
     <PackageVersion Include="Aspire.Hosting" Version="9.2.1" />
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="9.2.0" />
     <PackageVersion Include="Aspire.Hosting.Azure.Storage" Version="9.2.1" />
@@ -17,6 +17,7 @@
     <PackageVersion Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.2.0" />
     <PackageVersion Include="Aspire.RabbitMQ.Client" Version="9.1.0" />
     <PackageVersion Include="Aspire.RabbitMQ.Client.v7" Version="9.2.0" />
+    <PackageVersion Include="Azure.Storage.Blobs" Version="12.24.0" />
     <PackageVersion Include="CommunityToolkit.Aspire.Hosting.NodeJS.Extensions" Version="9.4.0" />
     <PackageVersion Include="EventFlow.MongoDB" Version="1.2.0" />
     <PackageVersion Include="FluentValidation" Version="11.11.0" />

--- a/apps/assignment-flow/AssignmentFlow.Application/Assessments/Assess/AIGraderAssessedConsumer.cs
+++ b/apps/assignment-flow/AssignmentFlow.Application/Assessments/Assess/AIGraderAssessedConsumer.cs
@@ -11,8 +11,6 @@ public class AIGraderAssessedConsumer(
 {
     public async Task Consume(ConsumeContext<ISubmissionGradingResult> context)
     {
-        logger.LogInformation("received: {},", context.Message.AssessmentId);
-
         logger.LogInformation(
             "received: {AssessmentId}, ScoreBreakdowns: {ScoreBreakdowns}, Errors: {Errors}",
             context.Message.AssessmentId,

--- a/apps/assignment-flow/AssignmentFlow.Application/Assessments/StartAutoGrading/Command.cs
+++ b/apps/assignment-flow/AssignmentFlow.Application/Assessments/StartAutoGrading/Command.cs
@@ -26,10 +26,14 @@ public class CommandHandler(
             RubricId = command.RubricId
         }, cancellationToken: cancellationToken);
 
+        var metadata = rubric.MetadataJson is not null ? System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>>(rubric.MetadataJson) : [];
+
         await publishEndpoint.Publish<ISubmissionGradingStarted>(new
         {
             AssessmentId = aggregate.Id,
-            Criteria = MapCriteria(command.Submission, rubric)
+            Criteria = MapCriteria(command.Submission, rubric),
+            Metadata = metadata,
+            Attachments = rubric.Attachments.ToArray()
         },
         cancellationToken);
 

--- a/apps/assignment-flow/AssignmentFlow.Application/Gradings/GradingStateMachine.cs
+++ b/apps/assignment-flow/AssignmentFlow.Application/Gradings/GradingStateMachine.cs
@@ -25,7 +25,7 @@ public sealed class GradingStateMachine : StateMachine<GradingState, GradingTrig
             .Permit(GradingTrigger.FinishGrading, GradingState.Graded);
 
         Configure(GradingState.Graded)
-            .Permit(GradingTrigger.Start, GradingState.Started)
+            //.Permit(GradingTrigger.Start, GradingState.Started)
             .Permit(GradingTrigger.Complete, GradingState.Completed);
     }
 }

--- a/apps/assignment-flow/AssignmentFlow.IntegrationEvents/ISubmissionGradingResult.cs
+++ b/apps/assignment-flow/AssignmentFlow.IntegrationEvents/ISubmissionGradingResult.cs
@@ -7,5 +7,11 @@ public interface ISubmissionGradingResult
 {
     public string AssessmentId { get; set; }
     public List<ScoreBreakdown> ScoreBreakdowns { get; set; }
-    public List<string> Errors { get; set; }
+    public List<ErrorDetail> Errors { get; set; }
+}
+
+public class ErrorDetail
+{
+    public required string CriterionName { get; set; }
+    public required string Error { get; set; }
 }

--- a/apps/assignment-flow/AssignmentFlow.IntegrationEvents/ISubmissionGradingStarted.cs
+++ b/apps/assignment-flow/AssignmentFlow.IntegrationEvents/ISubmissionGradingStarted.cs
@@ -7,6 +7,8 @@ public interface ISubmissionGradingStarted
 {
     public string AssessmentId { get; set; }
     public Criterion[] Criteria { get; set; }
+    public Dictionary<string, object?> Metadata { get; set; }
+    public string[] Attachments { get; set; }
 }
 
 public class Criterion
@@ -22,5 +24,5 @@ public class Level
 {
     public required string Tag { get; set; }
     public required string Description { get; set; }
-    public required decimal Weight { get; set; } // FIXME: this is a string in payload
+    public required decimal Weight { get; set; }
 }

--- a/apps/rubric-engine/application/Bootstrapping/DbInitializer.cs
+++ b/apps/rubric-engine/application/Bootstrapping/DbInitializer.cs
@@ -1,17 +1,19 @@
-﻿using System;
-using System.Threading;
-using System.Threading.Tasks;
+﻿using Azure.Storage.Blobs;
 using EventFlow.PostgreSql;
 using EventFlow.PostgreSql.EventStores;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using RubricEngine.Application.Models;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace RubricEngine.Application.Bootstrapping;
 
 public class DbInitializer(
     RubricDbContext dbContext,
     IPostgreSqlDatabaseMigrator databaseMigrator,
+    BlobServiceClient blobServiceClient,
     ILogger<DbInitializer> logger)
 {
     public async Task InitializeAsync(bool applyMigrations = true)
@@ -30,7 +32,23 @@ public class DbInitializer(
                 await dbContext.Database.EnsureCreatedAsync();
             }
 
+            logger.LogDebug("Applying migrations to the EventFlow event store...");
             await EventFlowEventStoresPostgreSql.MigrateDatabaseAsync(databaseMigrator, CancellationToken.None);
+            logger.LogDebug("Database initialization completed successfully.");
+
+            logger.LogDebug("Ensuring blob container for rubric context store exists...");
+            var containerClient = blobServiceClient.GetBlobContainerClient("rubric-context-store");
+            var containerExists = await containerClient.ExistsAsync();
+            if (!containerExists.Value)
+            {
+                logger.LogDebug("Creating blob container for rubric context store...");
+                await containerClient.CreateAsync();
+                logger.LogDebug("Blob container created successfully.");
+            }
+            else
+            {
+                logger.LogDebug("Blob container 'rubric-context-store' already exists.");
+            }
         }
         catch (Exception ex)
         {

--- a/apps/rubric-engine/application/Migrations/20250614112859_AddAttachmentsAndMetadata.Designer.cs
+++ b/apps/rubric-engine/application/Migrations/20250614112859_AddAttachmentsAndMetadata.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using RubricEngine.Application.Models;
@@ -12,9 +13,11 @@ using RubricEngine.Application.Models;
 namespace RubricEngine.Application.Migrations
 {
     [DbContext(typeof(RubricDbContext))]
-    partial class RubricDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250614112859_AddAttachmentsAndMetadata")]
+    partial class AddAttachmentsAndMetadata
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/rubric-engine/application/Migrations/20250614112859_AddAttachmentsAndMetadata.cs
+++ b/apps/rubric-engine/application/Migrations/20250614112859_AddAttachmentsAndMetadata.cs
@@ -1,0 +1,57 @@
+﻿using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace RubricEngine.Application.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAttachmentsAndMetadata : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Status",
+                table: "Rubrics",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AddColumn<List<string>>(
+                name: "Attachments",
+                table: "Rubrics",
+                type: "text[]",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "MetadataJson",
+                table: "Rubrics",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Attachments",
+                table: "Rubrics");
+
+            migrationBuilder.DropColumn(
+                name: "MetadataJson",
+                table: "Rubrics");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Status",
+                table: "Rubrics",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(50)",
+                oldMaxLength: 50);
+        }
+    }
+}

--- a/apps/rubric-engine/application/Program.cs
+++ b/apps/rubric-engine/application/Program.cs
@@ -16,6 +16,7 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.AddNpgsqlDbContext<RubricDbContext>(connectionName: "rubricdb");
 builder.AddRabbitMQClient(connectionName: "messaging");
+builder.AddAzureBlobClient("rubric-context-store");
 
 builder.Services.AddBootstrapping(builder.Configuration, builder.Environment);
 builder.Services.AddShared(builder.Configuration, builder.Environment);

--- a/apps/rubric-engine/application/Protos/rubric.proto
+++ b/apps/rubric-engine/application/Protos/rubric.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-
+import "google/protobuf/any.proto";
 option csharp_namespace = "RubricEngine.Application.Protos";
 
 package rubric;
@@ -20,6 +20,8 @@ message RubricModel {
   repeated string performance_tags = 4;
   repeated CriterionModel criteria = 5;
   string status = 6; // "Draft" or "Used"
+  repeated string attachments = 7;
+  string metadataJson = 8;
 }
 
 message CriterionModel {

--- a/apps/rubric-engine/application/RubricEngine.Application.csproj
+++ b/apps/rubric-engine/application/RubricEngine.Application.csproj
@@ -11,9 +11,11 @@
   </ItemGroup>
 	
   <ItemGroup>
+	<PackageReference Include="Aspire.Azure.Storage.Blobs" />
 	<PackageReference Include="Aspire.Npgsql" />
 	<PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" />
 	<PackageReference Include="Aspire.RabbitMQ.Client.v7" />
+	<PackageReference Include="Azure.Storage.Blobs" />
 	<PackageReference Include="EventFlow" />
 	<PackageReference Include="EventFlow.EntityFramework" />
 	<PackageReference Include="EventFlow.PostgreSql" />

--- a/apps/rubric-engine/application/Rubrics/Create/CreateRubricResponse.cs
+++ b/apps/rubric-engine/application/Rubrics/Create/CreateRubricResponse.cs
@@ -13,4 +13,8 @@ public class CreateRubricResponse
     public required DateTimeOffset UpdatedOn { get; init; }
 
     public required string Status { get; init; }
+
+    public List<string>? Attachments { get; init; }
+
+    public Dictionary<string, object>? Metadata { get; init; }
 }

--- a/apps/rubric-engine/application/Rubrics/Create/EndpointHandler.cs
+++ b/apps/rubric-engine/application/Rubrics/Create/EndpointHandler.cs
@@ -50,7 +50,8 @@ public static class EndpointHandler
             Tags = rubric.PerformanceTags,
             Criteria = rubric.Criteria,
             UpdatedOn = rubric.UpdatedOn,
-            Status = rubric.Status
+            Status = rubric.Status,
+            Metadata = rubric.Metadata
         };
 
         return TypedResults.CreatedAtRoute<CreateRubricResponse>(response, "GetRubricById", new { id = rubricId });

--- a/apps/rubric-engine/application/Rubrics/EndpointHandlers.cs
+++ b/apps/rubric-engine/application/Rubrics/EndpointHandlers.cs
@@ -1,4 +1,5 @@
 ﻿using RubricEngine.Application.Rubrics.Create;
+using RubricEngine.Application.Rubrics.ProvisionContext;
 using RubricEngine.Application.Rubrics.Update;
 using SharpGrip.FluentValidation.AutoValidation.Endpoints.Extensions;
 
@@ -13,7 +14,8 @@ internal static class EndpointHandlers
             .AddFluentValidationAutoValidation()
             .WithTags("Rubrics")
             .MapCreateRubric()
-            .MapUpdateRubric();
+            .MapUpdateRubric()
+            .MapProvisionContext();
             
         return routeBuilder;
     }

--- a/apps/rubric-engine/application/Rubrics/EndpointHandlers.cs
+++ b/apps/rubric-engine/application/Rubrics/EndpointHandlers.cs
@@ -1,5 +1,6 @@
 ﻿using RubricEngine.Application.Rubrics.Create;
 using RubricEngine.Application.Rubrics.ProvisionContext;
+using RubricEngine.Application.Rubrics.RemoveAttachment;
 using RubricEngine.Application.Rubrics.Update;
 using SharpGrip.FluentValidation.AutoValidation.Endpoints.Extensions;
 
@@ -15,7 +16,8 @@ internal static class EndpointHandlers
             .WithTags("Rubrics")
             .MapCreateRubric()
             .MapUpdateRubric()
-            .MapProvisionContext();
+            .MapProvisionContext()
+            .MapRemoveAttachment();
             
         return routeBuilder;
     }

--- a/apps/rubric-engine/application/Rubrics/Grpc/RubricService.cs
+++ b/apps/rubric-engine/application/Rubrics/Grpc/RubricService.cs
@@ -29,8 +29,12 @@ public class RubricService(RubricDbContext dbContext) : RubricProtoService.Rubri
                     }) },
                     Plugin = c.Plugin,
                     Configuration = c.Configuration
-                }) }
+                }) },
+            MetadataJson = rubric.MetadataJson,
         };
+
+        rubricModel.PerformanceTags.AddRange(rubric.PerformanceTags);
+        rubricModel.Attachments.AddRange(rubric.Attachments);
 
         return rubricModel;
     }

--- a/apps/rubric-engine/application/Rubrics/ProvisionContext/AttachmentsProvisionedEvent.cs
+++ b/apps/rubric-engine/application/Rubrics/ProvisionContext/AttachmentsProvisionedEvent.cs
@@ -1,0 +1,10 @@
+﻿using EventFlow.Aggregates;
+using EventFlow.EventStores;
+
+namespace RubricEngine.Application.Rubrics.ProvisionContext;
+
+[EventVersion("attachmentsProvisioned", 1)]
+public class AttachmentsProvisionedEvent : AggregateEvent<RubricAggregate, RubricId>
+{
+    public required List<string> Attachments { get; set; }
+}

--- a/apps/rubric-engine/application/Rubrics/ProvisionContext/Command.cs
+++ b/apps/rubric-engine/application/Rubrics/ProvisionContext/Command.cs
@@ -1,0 +1,47 @@
+﻿using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using EventFlow.Commands;
+using System.Runtime.CompilerServices;
+
+namespace RubricEngine.Application.Rubrics.ProvisionContext;
+
+public class Command(RubricId aggregateId) : Command<RubricAggregate, RubricId>(aggregateId)
+{
+    public required IFormFileCollection Attachments { get; init; }
+    public required Dictionary<string, object>? Metadata { get; init; }
+}
+
+public class CommandHandler(BlobServiceClient client) : CommandHandler<RubricAggregate, RubricId, Command>
+{
+    public override async Task ExecuteAsync(RubricAggregate aggregate, Command command, CancellationToken cancellationToken)
+    {
+        if (aggregate.IsNew)
+            throw new InvalidOperationException(
+                $"Cannot provision context for rubric {aggregate.Id} because it has not been created yet.");
+
+        var container = client.GetBlobContainerClient("rubric-context-store");
+        var blobEntries = await ProcessAttachments(aggregate, command, container, cancellationToken)
+            .ToListAsync(cancellationToken: cancellationToken);
+
+        aggregate.ProvisionContext(blobEntries, command.Metadata);
+    }
+
+    private static async IAsyncEnumerable<string> ProcessAttachments(
+        RubricAggregate aggregate,
+        Command command,
+        BlobContainerClient container,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        var baseBlobName = $"{aggregate.Id}/";
+
+        foreach (var attachment in command.Attachments)
+        {
+            await using var stream = attachment.OpenReadStream();
+            var blobName = baseBlobName + attachment.FileName;
+            var blob = container.GetBlobClient(blobName);
+            await blob.UploadAsync(stream, new BlobUploadOptions(), cancellationToken);
+
+            yield return blobName;
+        }
+    }
+}

--- a/apps/rubric-engine/application/Rubrics/ProvisionContext/Command.cs
+++ b/apps/rubric-engine/application/Rubrics/ProvisionContext/Command.cs
@@ -41,7 +41,7 @@ public class CommandHandler(BlobServiceClient client) : CommandHandler<RubricAgg
             var blob = container.GetBlobClient(blobName);
             await blob.UploadAsync(stream, new BlobUploadOptions(), cancellationToken);
 
-            yield return blobName;
+            yield return attachment.FileName;
         }
     }
 }

--- a/apps/rubric-engine/application/Rubrics/ProvisionContext/EndpointHandler.cs
+++ b/apps/rubric-engine/application/Rubrics/ProvisionContext/EndpointHandler.cs
@@ -1,0 +1,51 @@
+﻿using EventFlow;
+using EventFlow.Queries;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using System.Text.Json;
+
+namespace RubricEngine.Application.Rubrics.ProvisionContext;
+
+public static class EndpointHandler
+{
+    public static IEndpointRouteBuilder MapProvisionContext(this IEndpointRouteBuilder endpoint)
+    {
+        endpoint.MapPost("/{id:required}/context", ProvisionContext)
+            .WithName("ProvisionContext")
+            .Produces<string>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .DisableAntiforgery(); // Disable for now
+
+        return endpoint;
+    }
+
+    private static async Task<IResult> ProvisionContext(
+        [FromRoute] string id,
+        IFormFileCollection files,
+        [FromForm] string? metadataJson,
+        ICommandBus commandBus,
+        IQueryProcessor queryProcessor,
+        IOptions<JsonOptions> jsonOptions,
+        CancellationToken cancellationToken)
+    {
+        var rubricId = RubricId.With(id);
+
+        Dictionary<string, object>? metadata = null;
+        if (!string.IsNullOrWhiteSpace(metadataJson))
+        {
+            metadata = JsonSerializer.Deserialize<Dictionary<string, object>>(
+                metadataJson,
+                jsonOptions.Value.JsonSerializerOptions
+            );
+        }
+
+        await commandBus.PublishAsync(new Command(rubricId)
+        {
+            Attachments = files,
+            Metadata = metadata
+        },
+        cancellationToken);
+
+        return Results.Ok("Provisioning complete.");
+    }
+}

--- a/apps/rubric-engine/application/Rubrics/RemoveAttachment/AttachmentRemovedEvent.cs
+++ b/apps/rubric-engine/application/Rubrics/RemoveAttachment/AttachmentRemovedEvent.cs
@@ -1,0 +1,10 @@
+﻿using EventFlow.Aggregates;
+using EventFlow.EventStores;
+
+namespace RubricEngine.Application.Rubrics.RemoveAttachment;
+
+[EventVersion("attachmentRemoved", 1)]
+public class AttachmentRemovedEvent : AggregateEvent<RubricAggregate, RubricId>
+{
+    public required string RemovedAttachment { get; init; }
+}

--- a/apps/rubric-engine/application/Rubrics/RemoveAttachment/Command.cs
+++ b/apps/rubric-engine/application/Rubrics/RemoveAttachment/Command.cs
@@ -1,0 +1,36 @@
+﻿using Azure.Storage.Blobs;
+using EventFlow.Commands;
+
+namespace RubricEngine.Application.Rubrics.RemoveAttachment;
+
+public class Command(RubricId aggregateId, string reference) : Command<RubricAggregate, RubricId>(aggregateId)
+{
+    public string Reference { get; } = reference;
+}
+
+public class CommandHandler(BlobServiceClient client) : CommandHandler<RubricAggregate, RubricId, Command>
+{
+    public override async Task ExecuteAsync(RubricAggregate aggregate, Command command,
+        CancellationToken cancellationToken)
+    {
+        if (aggregate.IsNew)
+            throw new InvalidOperationException(
+                $"Cannot remove submission for grading {aggregate.Id} because it has not been created yet.");
+
+        var container = client.GetBlobContainerClient("rubric-context-store");
+        var attachmentPath = $"{aggregate.Id}/{command.Reference}";
+        try
+        {
+            BlobClient blobClient = container.GetBlobClient(attachmentPath);
+            await blobClient.DeleteIfExistsAsync(cancellationToken: cancellationToken);
+
+            aggregate.RemoveAttachment(command.Reference);
+        }
+        catch (Exception ex)
+        {
+            // Handle exceptions from the blob storage operations
+            throw new InvalidOperationException(
+                $"Failed to remove attachment {command.Reference} for rubric {aggregate.Id}", ex);
+        }
+    }
+}

--- a/apps/rubric-engine/application/Rubrics/RemoveAttachment/EndpointHandler.cs
+++ b/apps/rubric-engine/application/Rubrics/RemoveAttachment/EndpointHandler.cs
@@ -1,0 +1,34 @@
+﻿using EventFlow;
+using EventFlow.Queries;
+using Microsoft.AspNetCore.Mvc;
+
+namespace RubricEngine.Application.Rubrics.RemoveAttachment;
+
+public static class EndpointHandler
+{
+    public static IEndpointRouteBuilder MapRemoveAttachment(this IEndpointRouteBuilder endpoint)
+    {
+        endpoint.MapDelete("/{id:required}/attachments/{reference:required}", RemoveAttachment)
+            .WithName("RemoveAttachment")
+            .Produces<string>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status400BadRequest);
+
+        return endpoint;
+    }
+
+    private static async Task<IResult> RemoveAttachment(
+        [FromRoute] string id,
+        [FromRoute] string reference,
+        ICommandBus commandBus,
+        IQueryProcessor queryProcessor,
+        IHttpContextAccessor contextAccessor,
+        CancellationToken cancellationToken)
+    {
+        var rubricId = RubricId.With(id);
+        await commandBus.PublishAsync(
+            new Command(rubricId, reference),
+            cancellationToken);
+
+        return TypedResults.Ok();
+    }
+}

--- a/apps/rubric-engine/application/Rubrics/Rubric.cs
+++ b/apps/rubric-engine/application/Rubrics/Rubric.cs
@@ -4,6 +4,7 @@ using JsonApiDotNetCore.Resources;
 using JsonApiDotNetCore.Resources.Annotations;
 using RubricEngine.Application.Rubrics.Complete;
 using RubricEngine.Application.Rubrics.Create;
+using RubricEngine.Application.Rubrics.ProvisionContext;
 using RubricEngine.Application.Rubrics.Update;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
@@ -19,7 +20,8 @@ public class Rubric :
     IAmReadModelFor<RubricAggregate, RubricId, CriteriaUpdatedEvent>,
     IAmReadModelFor<RubricAggregate, RubricId, PerformanceTagsUpdatedEvent>,
     IAmReadModelFor<RubricAggregate, RubricId, RubricUsedEvent>,
-    IAmReadModelFor<RubricAggregate, RubricId, MetadataUpdatedEvent>
+    IAmReadModelFor<RubricAggregate, RubricId, MetadataUpdatedEvent>,
+    IAmReadModelFor<RubricAggregate, RubricId, AttachmentsProvisionedEvent>
 {
     [Attr(Capabilities = AllowView | AllowSort | AllowFilter)]
     [MaxLength(ModelConstants.ShortText)]
@@ -115,6 +117,16 @@ public class Rubric :
         MetadataJson = domainEvent.AggregateEvent.MetadataJson;
         UpdatedOn = domainEvent.Timestamp.ToUniversalTime();
         
+        return Task.CompletedTask;
+    }
+
+    public Task ApplyAsync(IReadModelContext context, IDomainEvent<RubricAggregate, RubricId, AttachmentsProvisionedEvent> domainEvent, CancellationToken cancellationToken)
+    {
+        Attachments ??= [];
+        Attachments.AddRange(domainEvent.AggregateEvent.Attachments);
+
+        UpdatedOn = domainEvent.Timestamp.ToUniversalTime();
+
         return Task.CompletedTask;
     }
 }

--- a/apps/rubric-engine/application/Rubrics/Rubric.cs
+++ b/apps/rubric-engine/application/Rubrics/Rubric.cs
@@ -5,6 +5,7 @@ using JsonApiDotNetCore.Resources.Annotations;
 using RubricEngine.Application.Rubrics.Complete;
 using RubricEngine.Application.Rubrics.Create;
 using RubricEngine.Application.Rubrics.ProvisionContext;
+using RubricEngine.Application.Rubrics.RemoveAttachment;
 using RubricEngine.Application.Rubrics.Update;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
@@ -21,7 +22,8 @@ public class Rubric :
     IAmReadModelFor<RubricAggregate, RubricId, PerformanceTagsUpdatedEvent>,
     IAmReadModelFor<RubricAggregate, RubricId, RubricUsedEvent>,
     IAmReadModelFor<RubricAggregate, RubricId, MetadataUpdatedEvent>,
-    IAmReadModelFor<RubricAggregate, RubricId, AttachmentsProvisionedEvent>
+    IAmReadModelFor<RubricAggregate, RubricId, AttachmentsProvisionedEvent>,
+    IAmReadModelFor<RubricAggregate, RubricId, AttachmentRemovedEvent>
 {
     [Attr(Capabilities = AllowView | AllowSort | AllowFilter)]
     [MaxLength(ModelConstants.ShortText)]
@@ -125,6 +127,14 @@ public class Rubric :
         Attachments ??= [];
         Attachments.AddRange(domainEvent.AggregateEvent.Attachments);
 
+        UpdatedOn = domainEvent.Timestamp.ToUniversalTime();
+
+        return Task.CompletedTask;
+    }
+
+    public Task ApplyAsync(IReadModelContext context, IDomainEvent<RubricAggregate, RubricId, AttachmentRemovedEvent> domainEvent, CancellationToken cancellationToken)
+    {
+        Attachments?.Remove(domainEvent.AggregateEvent.RemovedAttachment);
         UpdatedOn = domainEvent.Timestamp.ToUniversalTime();
 
         return Task.CompletedTask;

--- a/apps/rubric-engine/application/Rubrics/RubricAggregate.cs
+++ b/apps/rubric-engine/application/Rubrics/RubricAggregate.cs
@@ -2,6 +2,7 @@ using EventFlow.Aggregates;
 using EventFlow.Core;
 using EventFlow.Extensions;
 using RubricEngine.Application.Rubrics.Complete;
+using RubricEngine.Application.Rubrics.RemoveAttachment;
 using RubricEngine.Application.Rubrics.Update;
 
 namespace RubricEngine.Application.Rubrics;
@@ -87,6 +88,16 @@ public class RubricAggregate : AggregateRoot<RubricAggregate, RubricId>
             {
                 MetadataJson = System.Text.Json.JsonSerializer.Serialize(metadata) // Use the static JsonSerializer from System.Text.Json
             });
+    }
+
+    public void RemoveAttachment(string attachment)
+    {
+        RubricCanBeUpdatedSpecification.New().ThrowDomainErrorIfNotSatisfied(State);
+
+        Emit(new AttachmentRemovedEvent
+        {
+            RemovedAttachment = attachment
+        });
     }
 
     private void ConditionalEmit(bool condition, Func<AggregateEvent<RubricAggregate, RubricId>> eventPredicate)

--- a/apps/rubric-engine/application/Rubrics/RubricAggregate.cs
+++ b/apps/rubric-engine/application/Rubrics/RubricAggregate.cs
@@ -72,6 +72,23 @@ public class RubricAggregate : AggregateRoot<RubricAggregate, RubricId>
         });
     }
 
+    public void ProvisionContext(List<string> attachments, Dictionary<string, object>? metadata = null)
+    {
+        //TODO: Create new specification
+        RubricCanBeUpdatedSpecification.New().ThrowDomainErrorIfNotSatisfied(State);
+
+        Emit(new ProvisionContext.AttachmentsProvisionedEvent
+        {
+            Attachments = attachments,
+        });
+
+        ConditionalEmit(metadata is not null,
+            () => new MetadataUpdatedEvent
+            {
+                MetadataJson = System.Text.Json.JsonSerializer.Serialize(metadata) // Use the static JsonSerializer from System.Text.Json
+            });
+    }
+
     private void ConditionalEmit(bool condition, Func<AggregateEvent<RubricAggregate, RubricId>> eventPredicate)
     {
         if (condition)

--- a/apps/rubric-engine/application/Rubrics/RubricAggregate.cs
+++ b/apps/rubric-engine/application/Rubrics/RubricAggregate.cs
@@ -55,6 +55,12 @@ public class RubricAggregate : AggregateRoot<RubricAggregate, RubricId>
             {
                 Criteria = command.Criteria!
             });
+
+        ConditionalEmit(command.Metadata is not null,
+            () => new MetadataUpdatedEvent
+            {
+                MetadataJson = System.Text.Json.JsonSerializer.Serialize(command.Metadata!) // Use the static JsonSerializer from System.Text.Json
+            });
     }
 
     public void CompleteRubric(Rubrics.Complete.Command command)

--- a/apps/rubric-engine/application/Rubrics/RubricWriteModel.cs
+++ b/apps/rubric-engine/application/Rubrics/RubricWriteModel.cs
@@ -1,6 +1,7 @@
 using EventFlow.Aggregates;
 using RubricEngine.Application.Rubrics.Complete;
 using RubricEngine.Application.Rubrics.Create;
+using RubricEngine.Application.Rubrics.ProvisionContext;
 using RubricEngine.Application.Rubrics.Update;
 namespace RubricEngine.Application.Rubrics;
 
@@ -11,6 +12,7 @@ public class RubricWriteModel
     public RubricName Name { get; private set; } = RubricName.Empty;
     public List<PerformanceTag> PerformanceTags { get; private set; } = [];
     public List<Criterion> Criteria { get; private set; } = [];
+    public List<string> Attachments { get; private set; } = [];
     public string MetadataJson { get; private set; } = string.Empty;
 
     public string GradingId = string.Empty;
@@ -46,5 +48,10 @@ public class RubricWriteModel
     internal void Apply(MetadataUpdatedEvent @event)
     {
         MetadataJson = @event.MetadataJson;
+    }
+
+    internal void Apply(AttachmentsProvisionedEvent @event)
+    {
+        Attachments = @event.Attachments;
     }
 }

--- a/apps/rubric-engine/application/Rubrics/RubricWriteModel.cs
+++ b/apps/rubric-engine/application/Rubrics/RubricWriteModel.cs
@@ -2,6 +2,7 @@ using EventFlow.Aggregates;
 using RubricEngine.Application.Rubrics.Complete;
 using RubricEngine.Application.Rubrics.Create;
 using RubricEngine.Application.Rubrics.ProvisionContext;
+using RubricEngine.Application.Rubrics.RemoveAttachment;
 using RubricEngine.Application.Rubrics.Update;
 namespace RubricEngine.Application.Rubrics;
 
@@ -52,6 +53,11 @@ public class RubricWriteModel
 
     internal void Apply(AttachmentsProvisionedEvent @event)
     {
-        Attachments = @event.Attachments;
+        Attachments.AddRange(@event.Attachments);
+    }
+
+    internal void Apply(AttachmentRemovedEvent @event)
+    {
+        Attachments.Remove(@event.RemovedAttachment);
     }
 }

--- a/apps/rubric-engine/application/Rubrics/RubricWriteModel.cs
+++ b/apps/rubric-engine/application/Rubrics/RubricWriteModel.cs
@@ -11,6 +11,7 @@ public class RubricWriteModel
     public RubricName Name { get; private set; } = RubricName.Empty;
     public List<PerformanceTag> PerformanceTags { get; private set; } = [];
     public List<Criterion> Criteria { get; private set; } = [];
+    public string MetadataJson { get; private set; } = string.Empty;
 
     public string GradingId = string.Empty;
 
@@ -40,5 +41,10 @@ public class RubricWriteModel
     {
         GradingId = @event.GradingId;
         Status = RubricStatus.Used.ToString();
+    }
+
+    internal void Apply(MetadataUpdatedEvent @event)
+    {
+        MetadataJson = @event.MetadataJson;
     }
 }

--- a/apps/rubric-engine/application/Rubrics/Update/Command.cs
+++ b/apps/rubric-engine/application/Rubrics/Update/Command.cs
@@ -7,6 +7,8 @@ public class Command(RubricId id) : Command<RubricAggregate, RubricId>(id)
     public RubricName? Name { get; init; }
     public List<PerformanceTag>? PerformanceTags { get; init; }
     public List<Criterion>? Criteria { get; init; }
+    
+    public Dictionary<string, object>? Metadata { get; init; }
 }
 
 public class CommandHandler : CommandHandler<RubricAggregate, RubricId, Command>

--- a/apps/rubric-engine/application/Rubrics/Update/EndpointHandler.cs
+++ b/apps/rubric-engine/application/Rubrics/Update/EndpointHandler.cs
@@ -24,7 +24,8 @@ public static class EndpointHandler
         {
             Name = request.RubricName?.ToRubricName(),
             PerformanceTags = request.Tags?.ToPerformanceTags(),
-            Criteria = request.Criteria?.ToCriteria()
+            Criteria = request.Criteria?.ToCriteria(),
+            Metadata = request.Metadata
         };
 
         await commandBus.PublishAsync(command, cancellationToken);

--- a/apps/rubric-engine/application/Rubrics/Update/MetadataUpdatedEvent.cs
+++ b/apps/rubric-engine/application/Rubrics/Update/MetadataUpdatedEvent.cs
@@ -1,0 +1,10 @@
+﻿using EventFlow.Aggregates;
+using EventFlow.EventStores;
+
+namespace RubricEngine.Application.Rubrics.Update;
+
+[EventVersion("metadataUpdated", 1)]
+public class MetadataUpdatedEvent : AggregateEvent<RubricAggregate, RubricId>
+{
+    public required string MetadataJson { get; init; }
+}

--- a/apps/rubric-engine/application/Rubrics/Update/UpdateRubricRequest.cs
+++ b/apps/rubric-engine/application/Rubrics/Update/UpdateRubricRequest.cs
@@ -10,4 +10,6 @@ public class UpdateRubricRequest
     public List<string>? Tags { get; init; }
 
     public List<CriterionApiContract>? Criteria { get; init; }
+    
+    public Dictionary<string, object>? Metadata { get; init; }
 }

--- a/tools/app-host/Program.cs
+++ b/tools/app-host/Program.cs
@@ -70,6 +70,7 @@ if (builder.Configuration.GetValue<bool>("RubricEngine:Enabled", true))
     rubricEngine = builder
         .AddProject<Projects.RubricEngine_Application>("rubric-engine")
         .WithHttpsEndpoint(
+            name: "rubric-engine-https",
             port: builder.Configuration.GetValue<int?>("RubricEngine:Port"),
             isProxied: toProxy
         )
@@ -85,6 +86,7 @@ if (builder.Configuration.GetValue<bool>("AssignmentFlow:Enabled", true))
     assignmentFlow = builder
         .AddProject<Projects.AssignmentFlow_Application>("assignmentflow-application")
         .WithHttpsEndpoint(
+            name: "assignment-flow-https",
             port: builder.Configuration.GetValue<int?>("AssignmentFlow:Port"),
             isProxied: toProxy
         )


### PR DESCRIPTION
This pull request introduces significant updates across multiple files to enhance functionality, improve database schema, and extend support for Azure Blob Storage in the `rubric-engine` application. Key changes include updates to package dependencies, modifications to the database schema, and new features for handling rubric attachments and metadata.

### Package Updates:
* [`Directory.Packages.props`](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156L7-R7): Updated `Aspire.Azure.Storage.Blobs` to version `9.3.1` and added `Azure.Storage.Blobs` version `12.24.0`. [[1]](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156L7-R7) [[2]](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156R20)
* [`RubricEngine.Application.csproj`](diffhunk://#diff-2b1005b339b7454bcf41ee5e2f7be04964850b5c346b7f6311d0eaaa1351361eR14-R18): Added package references for `Aspire.Azure.Storage.Blobs` and `Azure.Storage.Blobs`.

### Database Schema Enhancements:
* [`RubricDbContextModelSnapshot.cs`](diffhunk://#diff-c340ab00a6d80a489c9db59cdc9f1436ba2053a7c0d68aa945041573bac40139R32-R37): Added support for `Attachments` and `MetadataJson` fields in the `Rubrics` table and updated column constraints for `Status`, `Name`, `Plugin`, and `Description`. [[1]](diffhunk://#diff-c340ab00a6d80a489c9db59cdc9f1436ba2053a7c0d68aa945041573bac40139R32-R37) [[2]](diffhunk://#diff-c340ab00a6d80a489c9db59cdc9f1436ba2053a7c0d68aa945041573bac40139L43-R50) [[3]](diffhunk://#diff-c340ab00a6d80a489c9db59cdc9f1436ba2053a7c0d68aa945041573bac40139R76-R89) [[4]](diffhunk://#diff-c340ab00a6d80a489c9db59cdc9f1436ba2053a7c0d68aa945041573bac40139L99-R123)
* `AddAttachmentsAndMetadata.Designer.cs` & `AddAttachmentsAndMetadata.cs`: Introduced a migration to add `Attachments` and `MetadataJson` columns to the `Rubrics` table and updated column constraints. [[1]](diffhunk://#diff-1a5cd9097f9b939133a52744a1a447af1c595a3cbd18aa6a9cb4544c526213baR1-R147) [[2]](diffhunk://#diff-598880e57cefdfc2e4c2802488309a414aecd3a5c3af6b5aaadf42b1ccfb9ab5R1-R57)

### Azure Blob Storage Integration:
* [`DbInitializer.cs`](diffhunk://#diff-bca5fc68a5a10818581c1e6598305add42a2739d1be978d3e1c32c9aeffb96c8L1-R16): Added `BlobServiceClient` for managing blob containers and ensured the existence of a container for rubric context storage. [[1]](diffhunk://#diff-bca5fc68a5a10818581c1e6598305add42a2739d1be978d3e1c32c9aeffb96c8L1-R16) [[2]](diffhunk://#diff-bca5fc68a5a10818581c1e6598305add42a2739d1be978d3e1c32c9aeffb96c8R35-R51)
* [`Program.cs`](diffhunk://#diff-fe2853cd21e0f9fe4c9872ee8e978197413df52d64f0dd3b334e542b5330d7f7R19): Registered Azure Blob Client for `rubric-context-store`.

### Rubric Features:
* [`CreateRubricResponse.cs`](diffhunk://#diff-634a1ed3dc2796fc3084aeed99b04c91d40a37d5e2c889e4347424322dffeeb7R16-R19): Added `Attachments` and `Metadata` properties to support additional rubric features.
* [`EndpointHandlers.cs`](diffhunk://#diff-38ddada5789be02dbaaccf74fddbfac920125a3826c6a03f8c0284471ace9b53L16-R20): Extended endpoint mapping to include `ProvisionContext` and `RemoveAttachment` functionalities.
* [`AttachmentsProvisionedEvent.cs`](diffhunk://#diff-9b1015d209a7056b3ef383a723d4d8a26da9b6ea2a3badb36b0355bb6d5ee646R1-R10): Introduced an event for provisioning attachments in rubrics.